### PR TITLE
fix: store cinema's ticket URL on booking after presale form submit

### DIFF
--- a/pkg/api/handler/reportforms.go
+++ b/pkg/api/handler/reportforms.go
@@ -179,13 +179,15 @@ func createPresaleForm(service reportform.UseCase, log *slog.Logger) fiber.Handl
 			// Look up the most recent presale report for this booking so we can
 			// show it as "last reported" text and prefill the quantity field.
 			var prevAmount int
+			var prevURL string
 			forkopsData, forkopsErr := service.GetFromD365(
 				"new_forkops?$filter=_new_boking_value%20eq%20" + item.ID +
-					"&$orderby=createdon%20desc&$top=1&$select=new_unit")
+					"&$orderby=createdon%20desc&$top=1&$select=new_unit,new_forkopsurl")
 			if forkopsErr == nil {
 				forkops := entity.DynamicsForkops{}
 				if json.Unmarshal(forkopsData, &forkops) == nil && len(forkops.Value) > 0 {
 					prevAmount = forkops.Value[0].Unit
+					prevURL = forkops.Value[0].Url
 				}
 			}
 
@@ -196,7 +198,7 @@ func createPresaleForm(service reportform.UseCase, log *slog.Logger) fiber.Handl
 				Text:           item.Name,
 				Date:           item.ShowDate,
 				Amount:         prevAmount,
-				Url:            item.Url,
+				Url:            prevURL,
 				ExpirationTime: time.Now().Add(24 * time.Hour),
 				FormID:         formID,
 				Discounts:      item.Discounts,

--- a/pkg/api/handler/reportforms.go
+++ b/pkg/api/handler/reportforms.go
@@ -377,6 +377,9 @@ func postFormResult(service reportform.UseCase, log *slog.Logger) fiber.Handler 
 				ticketURL := c.FormValue("10_" + strconv.Itoa(id))
 
 				service.PostToD365("new_forkops", `{"new_boking@odata.bind":"new_bokningarkunds(`+event.ID.String()+`)","new_forkopsurl":"`+ticketURL+`","new_unit":`+strconv.Itoa(qty)+`}`)
+				if _, err := service.PostToD365("new_bokningarkunds("+event.ID.String()+")", `{"new_forkopsurl":"`+ticketURL+`"}`); err != nil {
+					l.Error("failed to update booking URL in D365", "booking_id", event.ID.String(), "err", err)
+				}
 
 				receipt = append(receipt, receiptEvent{
 					Name: event.Name,


### PR DESCRIPTION
## Summary

- When a presale form was created, `new_bokningarkunds` was patched with the registration form URL (`registrera.folketshusochparker.se/form/...`).
- After the cinema submitted the form and entered their own ticket sales URL (e.g. `https://biografspegeln.se/...`), that URL was posted to `new_forkops` but the **booking record was never updated** — leaving the wrong URL visible in Dynamics.
- Fix: after posting to `new_forkops`, also PATCH the booking with the cinema-entered `ticketURL`.

## Test plan

- [ ] Create a presale form for a cinema customer
- [ ] Submit the form entering a cinema ticket page URL (e.g. `https://biografspegeln.se/...`)
- [ ] Verify in Dynamics that `new_bokningarkunds.new_forkopsurl` is updated to the cinema's URL, not the registration form URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)